### PR TITLE
Always use === and !== instead of == and != in DOM

### DIFF
--- a/code/dom/beta.js
+++ b/code/dom/beta.js
@@ -586,7 +586,7 @@ var pl;
 
 	// unify
 	pl.type.DOM.prototype.unify = function( obj, _ ) {
-		if( pl.type.is_dom_object( obj ) && this.object == obj.object ) {
+		if( pl.type.is_dom_object( obj ) && this.object === obj.object ) {
 			return new pl.type.State( obj, new pl.type.Substitution() );
 		}
 		return null;


### PR DESCRIPTION
!= and == where used in one place in DOM. This change replaces all usages of double equals with triple equals. There is a good explanation [here](https://stackoverflow.com/questions/359494/which-equals-operator-vs-should-be-used-in-javascript-comparisons) why the tiriple-equals variant should always be used.