### PR TITLE
Add atomic_concat/3 built-in predicate

### DIFF
--- a/modules/core.js
+++ b/modules/core.js
@@ -7134,6 +7134,33 @@
 			}
 		},
 		
+		// atomic_concat/3
+		"atomic_concat/3": function( thread, point, atom ) {
+			var atomic1 = atom.args[0], atomic2 = atom.args[1], concat = atom.args[2];
+			if( pl.type.is_variable( atomic1 ) || pl.type.is_variable( atomic2 ) ) {
+				thread.throw_error( pl.error.instantiation( atom.indicator ) );
+			} else if( !pl.type.is_atomic( atomic1 ) ) {
+				thread.throw_error( pl.error.type( "atomic", atomic1, atom.indicator ) );
+			} else if( !pl.type.is_atomic( atomic2 ) ) {
+				thread.throw_error( pl.error.type( "atomic", atomic2, atom.indicator ) );
+			} else if( !pl.type.is_variable( concat ) && !pl.type.is_atom( concat ) ) {
+				thread.throw_error( pl.error.type( "atom", concat, atom.indicator ) );
+			} else {
+				var id = "";
+				if( pl.type.is_atom( atomic1 ) ) {
+					id += atomic1.id;
+				} else {
+					id += "" + atomic1.value;
+				}
+				if( pl.type.is_atom( atomic2 ) ) {
+					id += atomic2.id;
+				} else {
+					id += "" + atomic2.value;
+				}
+				thread.prepend( [new State( point.goal.replace( new Term( "=", [id, concat] ) ), point.substitution, point )] );
+			}
+		},
+
 		// atomic_list_concat/2
 		"atomic_list_concat/2": function( thread, point, atom ) {
 			var list = atom.args[0], concat = atom.args[1];


### PR DESCRIPTION
This predicate is a built-in predicate in LVM, SWI-Prolog, Trealla Prolog, and YAP. It's also easily defined using existing built-in predicate in CxProlog, ECLiPSe, and XSB (which provide equivalents to the `atomic_list_concat/2-3` predicates).