### PR TITLE
Avoid double-calling success callback while consulting nested modules.

### DIFF
--- a/modules/core.js
+++ b/modules/core.js
@@ -1217,6 +1217,7 @@
 			});
 		} else if(expr.value.body === null && expr.value.head.indicator === ":-/1") {
 			var result = thread.run_directive(expr.value.head.args[0], options);
+			if (result === "recursive") return true;
 			async = async || (result === true);
 			if(async)
 				parseProgram(thread, options.string, options);
@@ -4580,7 +4581,7 @@
 								options.error(pl.error.existence("module", module_id, atom.indicator));
 							}
 						});
-						return true;
+						return "recursive";
 					}
 				}
 			},


### PR DESCRIPTION
I was finding the success callback to be called multiple times when modules are using other non-library modules.

The following example can produce the issue:

```prolog
% first.pl

:- module(first, []).
:- use_module('./second.pl').
% :- initialization(test_predicate).
```

```prolog
% second.pl
:- module(second, [test_predicate/0]).

test_predicate.
```

```javascript
// main.js
const pl = require("../modules/core.js");

const session = pl.create();
session.consult("./first.pl", {
  success: () => {
    console.trace("Success!");
  },
  error: (error) => {
    console.error(error.toString());
  },
});
```

When run on the unchanged master, this logs the `Success!` traces twice.

Additionally, uncommenting the `initialization` line causes the program to fail, as the parsing continued too early, before the module was loaded. I believe this to be an error (it's certainly unintuitive), though I am no expert on the correct processing of a Prolog program so I could be mistaken here.

After my change, `Success!` is only printed once, at the end.

I believe the issues comes from the recursive use of `parseProgram` in multiple places: `use_module` was returning true (to indicate async) which indicates to `parseProgramExpansion` and `parseProgram` that they should continue recursively, rather than imperatively. But then, inside of `use_module`, it is also recursively calling `parseProgram`, causing it to be parsed multiple times. As far as I can tell, there is no need to call `parseProgram` recursively twice.
